### PR TITLE
Minor typo

### DIFF
--- a/doc/lang.txt
+++ b/doc/lang.txt
@@ -824,7 +824,7 @@ TABLE OF CONTENTS:
 
             Acceptable:
                 const length_mm = {;...} /* '_' disambiguates returned values.  */
-                cosnt length_cm = {;...}
+                const length_cm = {;...}
 
     6.3. Collections:
 


### PR DESCRIPTION
Found it when I was searching the codebase for a definition and had a typo in my search.