### PR TITLE
Some (slightly weird) fixes

### DIFF
--- a/6/main.c
+++ b/6/main.c
@@ -33,8 +33,8 @@ Asmsyntax asmsyntax;
 
 static void usage(char *prog)
 {
-	printf("%s [-?] [-o outfile] [-d[dbgopts]] inputs\n", prog);
-	printf("\t-?\tPrint this help\n");
+	printf("%s [-?|-h] [-o outfile] [-d[dbgopts]] inputs\n", prog);
+	printf("\t-?|-h\tPrint this help\n");
 	printf("\t-o\tOutput to outfile\n");
 	printf("\t-S\tGenerate assembly source alongside object code\n");
 	printf("\t-c\tEnable additional (possibly flaky) checking\n");
@@ -165,7 +165,7 @@ int main(int argc, char **argv)
 
 	outfile = NULL;
 
-	optinit(&ctx, "cd:hSo:I:9G", argv, argc);
+	optinit(&ctx, "cd:?hSo:I:9G", argv, argc);
 	asmsyntax = Defaultasm;
 	while (!optdone(&ctx)) {
 		switch (optnext(&ctx)) {

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 SUB = parse \
       mi \
+      util \
       6 \
       muse \
       rt \
-      util \
       doc
 
 EXTRA=buildmyr

--- a/util/util.c
+++ b/util/util.c
@@ -175,7 +175,7 @@ int optnext(Optctx *ctx)
 	c = *ctx->curarg;
 	ctx->curarg++;
 	if (!optinfo(ctx, c, &take, &mand)) {
-		printf("Unexpected argument %c\n", *ctx->curarg);
+		printf("Unexpected argument %c\n", c);
 		exit(1);
 	}
 


### PR DESCRIPTION
Basically, `6m -h` resulted in:

```
6m [-?] [-o outfile] [-d[dbgopts]] inputs
	-?	Print this help
	-o	Output to outfile
	-S	Generate assembly source alongside object code
	-c	Enable additional (possibly flaky) checking
	-I path	Add 'path' to use search path
	-d	Print debug dumps. Recognized options: f r p i
	-G	Generate asm in gas syntax
	-8	Generate asm in plan 9 syntax
	-d opts: additional debug logging. Options are listed below:
		f: log folded trees
		l: log lowered pre-cfg trees
		T: log tree immediately
		r: log register allocation activity
		i: log instruction selection activity
		u: log type unifications
```

So `6m -h` printed the help, but the help says to run `6m -?`, which says:

```
Unexpected argument
```

Also, running `6m -` prints:

```
Unexpected argument X
```

???

So I tried to fix it...but it didn't seem to have an effect. Because *the library order in the Makefile was wrong*. So I fixed that too!
