### PR TITLE
Update bsearch and lsearch to take a key function.

### DIFF
--- a/lib/std/search.myr
+++ b/lib/std/search.myr
@@ -2,14 +2,14 @@ use "cmp"
 use "option"
 
 pkg std =
-	generic lsearch	: (sl : @t[:], val : @t, cmp : (a : @t, b : @t -> order) -> option(@idx::(integral,numeric)))
-	generic bsearch	: (sl : @t[:], val : @t, cmp : (a : @t, b : @t -> order) -> option(@idx::(integral,numeric)))
+	generic lsearch	: (sl : @t[:], key : @kt, keyfn : (t : @t -> @kt), cmp : (a : @kt, b : @kt -> order) -> option(@idx::(integral,numeric)))
+	generic bsearch	: (sl : @t[:], key : @kt, keyfn : (t : @t -> @kt), cmp : (a : @kt, b : @kt -> order) -> option(@idx::(integral,numeric)))
 ;;
 
 /* linear search over a list of values */
-generic lsearch = {sl, val, cmp
+generic lsearch = {sl, key, keyfn, cmp
 	for var i = 0; i < sl.len; i++
-		match cmp(sl[i], val)
+		match cmp(keyfn(sl[i]), key)
 		| `Equal:
 			-> `Some i
 		| _:
@@ -20,7 +20,7 @@ generic lsearch = {sl, val, cmp
 }
 
 /* binary search over a sorted list of values. */
-generic bsearch  = {sl, val, cmp
+generic bsearch  = {sl, key, keyfn, cmp
 	var hi, lo, mid
 
 	lo = 0
@@ -28,7 +28,7 @@ generic bsearch  = {sl, val, cmp
 
 	while lo <= hi
 		mid = (hi + lo) / 2
-		match cmp(val, sl[mid])
+		match cmp(key, keyfn(sl[mid]))
 		| `Before:	hi = mid - 1
 		| `After:	lo = mid + 1
 		| `Equal:	

--- a/lib/std/test/search.myr
+++ b/lib/std/test/search.myr
@@ -3,16 +3,16 @@ use std
 const sl = [1, 3, 5, 8, 9, 33]
 
 const main = {
+	var keyfn = {x; -> x}
+	expect(std.lsearch(sl[:], 1, keyfn, std.numcmp), `std.Some 0)
+	expect(std.lsearch(sl[:], 33, keyfn, std.numcmp), `std.Some sl.len - 1)
+	expect(std.lsearch(sl[:], 5, keyfn, std.numcmp), `std.Some 2)
+	expect(std.lsearch(sl[:], 6, keyfn, std.numcmp), `std.None)
 
-	expect(std.lsearch(sl[:], 1, std.numcmp), `std.Some 0)
-	expect(std.lsearch(sl[:], 33, std.numcmp), `std.Some sl.len - 1)
-	expect(std.lsearch(sl[:], 5, std.numcmp), `std.Some 2)
-	expect(std.lsearch(sl[:], 6, std.numcmp), `std.None)
-
-	expect(std.bsearch(sl[:], 1, std.numcmp), `std.Some 0)
-	expect(std.bsearch(sl[:], 33, std.numcmp), `std.Some sl.len - 1)
-	expect(std.bsearch(sl[:], 5, std.numcmp), `std.Some 2)
-	expect(std.bsearch(sl[:], 6, std.numcmp), `std.None)
+	expect(std.bsearch(sl[:], 1, keyfn, std.numcmp), `std.Some 0)
+	expect(std.bsearch(sl[:], 33, keyfn, std.numcmp), `std.Some sl.len - 1)
+	expect(std.bsearch(sl[:], 5, keyfn, std.numcmp), `std.Some 2)
+	expect(std.bsearch(sl[:], 6, keyfn, std.numcmp), `std.None)
 }
 
 const expect = {a, b


### PR DESCRIPTION
This change means it is possible to search a list of
structs or tuples by a sub field. The search key
does not need to be the same as the searched type.