### PR TITLE
Ignore generated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-test/*.o
-test/*.use
-test/*.use
 !test/*.myr
 libstd/sys*.myr
 !libstd/sys*+*.myr
@@ -16,9 +13,9 @@ libstd/resolve.myr
 libstd/wait.myr
 rt/*.s
 !rt/*-*.s
-*/*.o
-*/*.use
-*/*.a
+*.o
+*.use
+*.a
 */.deps
 config.h
 config.mk

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,8 @@ muse/muse
 myrbuild/myrbuild
 *~
 tags
+configvar_cache
+lib/regex/redump
+mbld/config.myr
+mbld/mbld
+support/mdumpleak


### PR DESCRIPTION
I saw a bunch of untracked files show up after a build. I suspect none of these are things that should be tracked.