### PR TITLE
Support ',' as '\\'' in format string

### DIFF
--- a/lib/std/fmt.myr
+++ b/lib/std/fmt.myr
@@ -18,6 +18,7 @@ use "slpush"
 use "strbuf"
 use "strfind"
 use "striter"
+use "strjoin"
 use "strsplit"
 use "syswrap"
 use "syswrap-ss"
@@ -207,7 +208,15 @@ const fmtval = {sb, ty, ap, params
 	;;
 }
 
+const strreplace = {str, from, to
+        var sparts = std.strsplit(str, from)
+        var sparamstr = std.strjoin(sparts, to)
+        slfree(sparts)
+        -> sparamstr
+}
+
 const parseparams = {paramstr, optdesc
+        const cmask = "_=.-=-_"
 	var params, opts
 	var o, a, ha, gotarg, found
 
@@ -215,13 +224,17 @@ const parseparams = {paramstr, optdesc
 	if optdesc.len == 0 && paramstr.len > 0
 		std.fatal("invalid format options {}\n")
 	;;
-	params = strsplit(paramstr, ",")
+        /* Mask '\\,', so that we can use it in case we need a ',' in a format string, as in: */
+        /* 'std.put("{f=year is %Y\\, the day is %d}\n", date.mkdate(2017, 10, 30, ""))'. */
+        var sparamstr = strreplace(paramstr, "\\,", cmask)
+	params = strsplit(sparamstr, ",")
 	for p : params
 		/* parse out the key/value pair */
 		match std.strfind(p, "=")
 		| `std.Some idx:
 			o = p[:idx]
-			a = p[idx+1:]
+                        /* We can now safely unmask from '\\,' to ',': */
+                        a = strreplace(p[idx+1:], cmask, ",")
 			gotarg = true
 		| `std.None:
 			o = p
@@ -379,7 +392,7 @@ const fallbackfmt = {sb, params, tyenc, ap : valist# -> void
 			fmtval(sb, vatype(&subap), &subap, "")
 			if subap.tc.nelt == 1
 				sbfmt(sb, ",")
-			elif i != subap.tc.nelt -1 
+			elif i != subap.tc.nelt -1
 				sbfmt(sb, ", ")
 			;;
 		;;
@@ -394,7 +407,7 @@ const fallbackfmt = {sb, params, tyenc, ap : valist# -> void
 			fmtval(sb, vatype(&subap), &subap, "")
 			if subap.tc.nelt == 1
 				sbfmt(sb, ",")
-			elif i != subap.tc.nelt -1 
+			elif i != subap.tc.nelt -1
 				sbfmt(sb, ", ")
 			;;
 		;;


### PR DESCRIPTION
Currently the following will fail:

```
std.put("{f=year is %Y, the day is %d}\n", date.mkdate(2017, 10, 30, ""))
```
with the error "'invalid option ' the day is %d' dying'".

This PR will support the a syntax with a quoted ',' to allow its use in such format strings:

```
std.put("{f=year is %Y\\, the day is %d}\n", date.mkdate(2017, 10, 30, ""))
```

You might want to change the value of `const cmask`.
