### PR TITLE
Format bodyless union without trailing space

### DIFF
--- a/lib/std/fmt.myr
+++ b/lib/std/fmt.myr
@@ -267,7 +267,7 @@ const fallbackfmt = {sb, params, tyenc, ap : valist# -> void
 	var l_val : int64, ul_val : uint64
 	var z_val : size
 	var p_val : byte#
-        var c_val : char
+	var c_val : char
 	var s_val : byte[:]
 	var f32_val : flt32, f64_val : flt64
 	var i8 : int8, i16: int16, i32 : int32
@@ -380,7 +380,7 @@ const fallbackfmt = {sb, params, tyenc, ap : valist# -> void
 			fmtval(sb, vatype(&subap), &subap, "")
 			if subap.tc.nelt == 1
 				sbfmt(sb, ",")
-			elif i != subap.tc.nelt -1 
+			elif i != subap.tc.nelt -1
 				sbfmt(sb, ", ")
 			;;
 		;;
@@ -395,7 +395,7 @@ const fallbackfmt = {sb, params, tyenc, ap : valist# -> void
 			fmtval(sb, vatype(&subap), &subap, "")
 			if subap.tc.nelt == 1
 				sbfmt(sb, ",")
-			elif i != subap.tc.nelt -1 
+			elif i != subap.tc.nelt -1
 				sbfmt(sb, ", ")
 			;;
 		;;
@@ -411,8 +411,13 @@ const fallbackfmt = {sb, params, tyenc, ap : valist# -> void
 			ncnext(&nc)
 		;;
 		(subname, subenc) = ncnext(&nc)
-		sbfmt(sb, "`{} ", subname)
-		fmtval(sb, subenc, &subap, "")
+		sbfmt(sb, "`{}", subname)
+		match typedesc(subenc)
+		| `Tynone:
+		| _:
+			sbputc(sb, ' ')
+			fmtval(sb, subenc, &subap, "")
+		;;
 		vabytes(ap)
 	| `Tyname (name, desc):
 		subap = vaenter(ap)

--- a/lib/std/test/fmt.myr
+++ b/lib/std/test/fmt.myr
@@ -72,7 +72,7 @@ const builtins = {
 	check("666.91972", "{}", 666.91972)
 	check("1.0001", "{}", 1.0001)
 	check("0.000101323461002", "{}", 0.000101323461002)
-	check("(1, `Bar 123, `Foo )", "{}", (1, `Bar 123, `Foo))
+	check("(1, `Bar 123, `Foo)", "{}", (1, `Bar 123, `Foo))
 
 	/* tricky cases: min values for integers */
 	check("-128", "{}", (-128 : int8))
@@ -91,7 +91,7 @@ const builtins = {
 	/*check("[.a=foo, .b=123] true", "{} {}", s, true) BUSTED */
 
 	m = `First
-	check("`First  true", "{} {}", m, true)
+	check("`First true", "{} {}", m, true)
 	m = `Second 123
 	check("`Second 123 true", "{} {}", m, true)
 	m = `Third "foo"

--- a/test/tests
+++ b/test/tests
@@ -15,7 +15,7 @@
 #	C tells us that the result is on stdout,
 #         and should be compared to the contents of
 #         the file passed on the line.
-#       D 
+#       D
 #    result: Result value
 #	What we compare with. This should be self-
 #	evident.
@@ -87,7 +87,7 @@ B generic	E	42
 B genericval	E	42
 B trait-builtin	E	42
 B pkgtrait	E	42
-B gtrait	P	'`std.Before '
+B gtrait	P	'`std.Before'
 B emptytrait	E	123
 B traitimpl	P	246,44,meee
 # B compoundimpl	P	intptr,charptr BUGGERED
@@ -101,7 +101,7 @@ B genericmatch	E	15
 B genericrec	E	0
 B genericimpl	P	'int string @a @a[:]'
 B recgeneric	P	'built'
-B bigtyblob	P	'`U100 '
+B bigtyblob	P	'`U100'
 B genericchain	P	'val = 123'
 B genericmake	P	'val = 123'
 B genericuret	E	42


### PR DESCRIPTION
Currently unions without bodies are formatted with a trailing space (``[`None ]`` instead of `` [`None] ``). This PR changes that, and updates the tests to match.

I just recently got to try out the language, saw this behavior, and decided it was as good a place as any to get my feet wet—assuming the space wasn’t intended, at least! :)
