### PR TITLE
Properly align the stack pointer in _start

### DIFF
--- a/rt/start-freebsd.s
+++ b/rt/start-freebsd.s
@@ -15,6 +15,8 @@ sys$__cenvp:
  */
 .globl _start
 _start:
+	andq	$-16,%rsp		/* align the stack pointer */
+
 	/* load argc, argv, envp from stack */
 	movq	(%rdi),%rax		/* argc */
 	leaq	8(%rdi),%rbx		/* argv */

--- a/rt/start-linux.s
+++ b/rt/start-linux.s
@@ -16,6 +16,7 @@ sys$__cenvp:
 .globl _start
 _start:
 	movq	%rsp,%rbp
+	andq	$-16,%rsp		/* align the stack pointer */
 
 	/* load argc, argv, envp from stack */
 	movq	(%rbp),%rax		/* argc */

--- a/rt/start-netbsd.s
+++ b/rt/start-netbsd.s
@@ -24,6 +24,7 @@ sys$__cenvp:
 .globl _start
 _start:
 	movq	%rsp,%rbp
+	andq	$-16,%rsp		/* align the stack pointer */
 
 	/* load argc, argv, envp from stack */
 	movq	(%rbp),%rax		/* argc */

--- a/rt/start-openbsd.s
+++ b/rt/start-openbsd.s
@@ -25,6 +25,7 @@ sys$__cenvp:
 .globl _start
 _start:
 	movq	%rsp,%rbp
+	andq	$-16,%rsp		/* align the stack pointer */
 
 	/* load argc, argv, envp from stack */
 	movq	(%rbp),%rax		/* argc */

--- a/rt/start-osx.s
+++ b/rt/start-osx.s
@@ -16,6 +16,7 @@ _sys$__cenvp:
 .globl start
 start:
 	movq	%rsp,%rbp
+	andq	$-16,%rsp		/* align the stack pointer */
 
 	/* load argc, argv, envp from stack */
 	movq	(%rbp),%rax		/* argc */


### PR DESCRIPTION
This adds an instruction to the `start-<os>.s` files, aligning the stack pointer to the proper 16-byte boundary right after entering `_start`.

While a violation of the ABI, it doesn’t seems like this is causing problems in pure Myrddin yet. It has, however, caused me some trouble under macOS, where the dynamic linker (dyld) may abort the program when trying to call a dynamically linked function with a misaligned stack pointer.

It seems like Linux libc implementations also make sure to do this (see e.g. https://git.musl-libc.org/cgit/musl/tree/arch/x86_64/crt_arch.h#n10 and https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/x86_64/start.S;h=9edd17b60cd54ec9eef11c76ab02322dcb5d057a;hb=HEAD#l90).

I’m very new to this kind of low-level programming, so please let me know if I’m completely misunderstanding/overlooking something!

`make check` passes on my x86-64 machine running macOS 10.13.1, but I haven’t tested it anywhere else; while I don’t see how, it might break something on other platforms.
