### PR TITLE
Correctly invoke the linker when binding with C

### DIFF
--- a/mbld/deps.myr
+++ b/mbld/deps.myr
@@ -177,6 +177,7 @@ const myrdeps = {b, name, mt
 			for l : ll
 				std.slpush(&dynlibs, l)
 			;;
+			mt.isdyn = true
 		elif std.hassuffix(f, config.Objsuffix)
 			depends(g, go, p)
 		else
@@ -458,7 +459,7 @@ const linkcmd = {b, n, mt, bin, libs, dynlibs, istest
 	if std.sleq(opt_sys, "osx")
 		std.slpush(&n.cmd, std.sldup("-macosx_version_min"))
 		std.slpush(&n.cmd, std.sldup("10.6"))
-	elif std.sleq(opt_sys, "linux") && dynlibs.len != 0
+	elif std.sleq(opt_sys, "linux") && mt.isdyn
 		std.slpush(&n.cmd, std.sldup("-dynamic-linker"))
 		std.slpush(&n.cmd, std.sldup("/lib64/ld-linux-x86-64.so.2"))
 	;;

--- a/mbld/parse.myr
+++ b/mbld/parse.myr
@@ -472,6 +472,7 @@ const myrtarget = {b, p, targ
 		.islib=false,
 		.istest=istest,
 		.isbench=isbench,
+		.isdyn=false,
 		/* attrs */
 		.tags=tags,
 		.install=install,

--- a/mbld/types.myr
+++ b/mbld/types.myr
@@ -46,6 +46,7 @@ pkg bld =
 		islib	: bool
 		istest	: bool
 		isbench	: bool
+		isdyn	: bool
 		install	: bool
 
 	;;


### PR DESCRIPTION
It looks like if the glue.c file is a lib in the bld.proj then dynlibs will be empty when calling linkcmd(), so the dynamic-linker flag doesn't get added. 

This fixes the cbind-example which wasn't working.