### PR TITLE
Let mbld link C on OpenBSD

### DIFF
--- a/configure
+++ b/configure
@@ -84,7 +84,7 @@ case $OS in
         echo 'export SYS=openbsd' >> config.mk
         echo export INST_MAN=$prefix/man/man >> config.mk
         echo 'const Sys = "OpenBSD"' >> mbld/config.myr
-        echo 'const Linkcmd = ["ld", "-static", "-nopie"]' >> mbld/config.myr
+        echo 'const Linkcmd = ["ld", "-nopie"]' >> mbld/config.myr
         echo "const Manpath = \"man/man\"" >> mbld/config.myr
         ;;
     *)

--- a/configure
+++ b/configure
@@ -49,6 +49,7 @@ case $OS in
         echo export INST_MAN=$prefix/share/man/man >> config.mk
         echo 'const Sys = "Linux"' >> mbld/config.myr
         echo 'const Linkcmd = ["ld"]' >> mbld/config.myr
+        echo 'const Dlflags : byte[:][:] = [][:]' >> mbld/config.myr
         echo "const Manpath = \"share/man/man\"" >> mbld/config.myr
         ;;
     *Darwin*)
@@ -64,6 +65,7 @@ case $OS in
             '"-macosx_version_min", "10.6",'\
             ']' >> mbld/config.myr
         echo "const Manpath = \"share/man/man\"" >> mbld/config.myr
+        echo 'const Dlflags : byte[:][:] = [][:]' >> mbld/config.myr
 	env='[("MACOSX_DEPLOYMENT_TARGET", "10.6")][:]'
         ;;
     *FreeBSD*)
@@ -71,6 +73,7 @@ case $OS in
         echo export INST_MAN=$prefix/man/man >> config.mk
         echo 'const Sys = "FreeBSD"' >> mbld/config.myr
         echo 'const Linkcmd = ["ld"]' >> mbld/config.myr
+        echo 'const Dlflags : byte[:][:] = [][:]' >> mbld/config.myr
         echo "const Manpath = \"man/man\"" >> mbld/config.myr
         ;;
     *NetBSD*)
@@ -78,6 +81,7 @@ case $OS in
         echo export INST_MAN=$prefix/man/man >> config.mk
         echo 'const Sys = "NetBSD"' >> mbld/config.myr
         echo 'const Linkcmd = ["ld"]' >> mbld/config.myr
+        echo 'const Dlflags : byte[:][:] = [][:]' >> mbld/config.myr
         echo "const Manpath = \"man/man\"" >> mbld/config.myr
         ;;
     *OpenBSD*)
@@ -85,6 +89,7 @@ case $OS in
         echo export INST_MAN=$prefix/man/man >> config.mk
         echo 'const Sys = "OpenBSD"' >> mbld/config.myr
         echo 'const Linkcmd = ["ld", "-nopie"]' >> mbld/config.myr
+        echo 'const Dlflags : byte[:][:] = [][:]' >> mbld/config.myr
         echo "const Manpath = \"man/man\"" >> mbld/config.myr
         ;;
     *)

--- a/configure
+++ b/configure
@@ -90,7 +90,8 @@ case $OS in
         echo export INST_MAN=$prefix/man/man >> config.mk
         echo 'const Sys = "OpenBSD"' >> mbld/config.myr
         echo 'const Linkcmd = ["ld", "-nopie"]' >> mbld/config.myr
-        echo 'const Dlflags : byte[:][:] = [][:]' >> mbld/config.myr
+        echo 'const Dlflags = ["-dynamic-linker",' \
+            '"/usr/libexec/ld.so"]' >> mbld/config.myr
         echo "const Manpath = \"man/man\"" >> mbld/config.myr
         ;;
     *)

--- a/configure
+++ b/configure
@@ -49,7 +49,8 @@ case $OS in
         echo export INST_MAN=$prefix/share/man/man >> config.mk
         echo 'const Sys = "Linux"' >> mbld/config.myr
         echo 'const Linkcmd = ["ld"]' >> mbld/config.myr
-        echo 'const Dlflags : byte[:][:] = [][:]' >> mbld/config.myr
+        echo 'const Dlflags = ["-dynamic-linker",' \
+            '"/lib64/ld-linux-x86-64.so.2"]' >> mbld/config.myr
         echo "const Manpath = \"share/man/man\"" >> mbld/config.myr
         ;;
     *Darwin*)

--- a/mbld/config+plan9-x64.myr
+++ b/mbld/config+plan9-x64.myr
@@ -4,6 +4,7 @@ pkg config =
 	const Sys	= "Plan9"
 	const Objsuffix	= ".6"
 	const Linkcmd	= ["6l", "-l"]
+	const Dlflags	: byte[:][:] = [][:]
 	const Arcmd	= ["ar", "u"]
 	const Ascmd	= ["6a"]
 	const Directlib	= true

--- a/mbld/deps.myr
+++ b/mbld/deps.myr
@@ -455,18 +455,21 @@ const linkcmd = {b, n, mt, bin, libs, dynlibs, istest
 		std.slpush(&n.cmd, std.sldup(o))
 	;;
 
-	dynlink = addlibs(b, &n.cmd, libs, mt.incpath)
+	dynlink = addlibs(b, &n.cmd, libs, mt.incpath) || mt.isdyn
 	for l : dynlibs
 		std.slpush(&n.cmd, std.fmt("-l{}", l))
+	;;
+
+	if dynlink
+		for f : config.Dlflags
+			std.slpush(&n.cmd, std.sldup(f))
+		;;
 	;;
 
 	/* OSX warns if we don't add a version */
 	if std.sleq(opt_sys, "osx")
 		std.slpush(&n.cmd, std.sldup("-macosx_version_min"))
 		std.slpush(&n.cmd, std.sldup("10.6"))
-	elif std.sleq(opt_sys, "linux") && (dynlink || mt.isdyn)
-		std.slpush(&n.cmd, std.sldup("-dynamic-linker"))
-		std.slpush(&n.cmd, std.sldup("/lib64/ld-linux-x86-64.so.2"))
 	;;
 
 }

--- a/rt/start-openbsd.s
+++ b/rt/start-openbsd.s
@@ -60,6 +60,18 @@ _start:
 	movq	$1,%rax
 	syscall
 
+/*
+ * provide __guard_local for if we are
+ * linking against libc
+ */
+.section ".openbsd.randomdata", "aw"
+	.global	__guard_local
+	.hidden	__guard_local
+	.type	__guard_local, "object"
+	.p2align	3
+__guard_local:
+	.quad	0
+	.size	__guard_local, 8
 
 .section ".note.openbsd.ident", "a"
         .p2align 2


### PR DESCRIPTION
This lets mbld work for projects that bind C on OpenBSD.

Now that there's more than one OS that can do this, I thought it made sense to declare the dynamic linker flags in a config variable, while leaving it empty on platforms that haven't had support added (yet).

Also defines the __guard_local stack protector variable as OpenBSD's libc expects it.