### PR TITLE
Fix some leaks when freeing json

### DIFF
--- a/lib/json/parse.myr
+++ b/lib/json/parse.myr
@@ -54,12 +54,15 @@ const free = {j
 		for e : a
 			free(e)
 		;;
+		std.slfree(a)
 	| &(`Obj o):
 		for (k, v) : o
 			std.slfree(k)
 			free(v)
 		;;
+		std.slfree(o)
 	;;
+	std.free(j)
 }
 
 const parseelt = {p


### PR DESCRIPTION
Objects and arrays have an underlying slice
All types are an elt allocated with mk