### PR TITLE
Fix std.skipto

### DIFF
--- a/lib/bio/bio.myr
+++ b/lib/bio/bio.myr
@@ -410,6 +410,8 @@ const readdelim = {f, delim, drop
 		| `std.Err `Eof:
 			if !drop
 				ret = readinto(f, ret, f.rend - f.rstart)
+			else
+				f.rstart += f.rend - f.rstart
 			;;
 			if ret.len > 0
 				-> `std.Ok ret
@@ -428,6 +430,8 @@ const readdelim = {f, delim, drop
 				;;
 				if !drop
 					ret = readinto(f, ret, i - f.rstart)
+				else
+					f.rstart += i - f.rstart
 				;;
 				f.rstart += delim.len
 				-> `std.Ok ret
@@ -436,6 +440,8 @@ const readdelim = {f, delim, drop
 		;;
 		if !drop
 			ret = readinto(f, ret, f.rend - f.rstart)
+		else
+			f.rstart += f.rend - f.rstart
 		;;
 	;;
 	std.die("unreachable")


### PR DESCRIPTION
It would only skip past however many characters the delimeter was and
would hang if the delimeter wasn't found before eof

edit: and by std.skipto I mean bio.skipto, bah 