### PR TITLE
libjson: allow square brackets in strings

### DIFF
--- a/lib/json/parse.myr
+++ b/lib/json/parse.myr
@@ -354,8 +354,8 @@ const matchprefix = {p, pfx
 
 const unescaped = {c
 	-> c == 0x20 || c == 0x21 || \
-		(c >= 0x23 && c < 0x5b) || \
-		(c > 0x5d && c <= 0x10ffff)
+		(c >= 0x23 && c <= 0x5b) || \
+		(c >= 0x5d && c <= 0x10ffff)
 }
 
 const takespace = {p


### PR DESCRIPTION
The spec allows square brackets unescaped in strings 