### PR TITLE
Add convenience wrappers for atomic operations on pointers

### DIFF
--- a/lib/thread/atomic.myr
+++ b/lib/thread/atomic.myr
@@ -1,4 +1,5 @@
 use std
+use "common"
 
 pkg thread =
 	trait atomic @a :: integral,numeric @a =
@@ -13,6 +14,11 @@ pkg thread =
 	impl atomic int64
 	impl atomic uint32
 	impl atomic uint64
+
+	generic xgetptr : (p : @a## -> std.option(@a#))
+	generic xsetptr : (p : @a##, v : std.option(@a#) -> void)
+	generic xcasptr : (p : @a##, old : std.option(@a#), new : std.option(@a#) -> std.option(@a#))
+	generic xchgptr : (p : @a##, new : std.option(@a#) -> std.option(@a#))
 ;;
 
 impl atomic int32 =
@@ -56,6 +62,31 @@ impl atomic std.intptr =
 	xcas	= {p, old, new; -> xcasp(p, old, new)}
 	xchg	= {p, v; -> xchgp(p, v)}
 ;;
+
+generic xgetptr = {p
+	match xget((p : std.intptr#))
+	| 0: -> `std.None
+	| n: -> `std.Some (n : @a#)
+	;;
+}
+
+generic xsetptr = {p, v
+	xset((p : std.intptr#), (std.getv(v, Zptr) : std.intptr))
+}
+
+generic xcasptr = {p, old, new
+	match xcas((p : std.intptr#), (std.getv(old, Zptr) : std.intptr), (std.getv(new, Zptr) : std.intptr))
+	| 0: -> `std.None
+	| n: -> `std.Some (n : @a#)
+	;;
+}
+
+generic xchgptr = {p, new
+	match xchg((p : std.intptr#), (std.getv(new, Zptr) : std.intptr))
+	| 0: -> `std.None
+	| n: -> `std.Some (n : @a#)
+	;;
+}
 
 extern const xget32	: (p : uint32# -> uint32)
 extern const xget64	: (p : uint64# -> uint64)

--- a/lib/thread/test/atomic.myr
+++ b/lib/thread/test/atomic.myr
@@ -16,6 +16,8 @@ const main = {
 		/* nothing */
 	;;
 	std.assert(val == 2_000_000, "atomics are broken\n")
+
+	testintptr()
 }
 
 const incvar = {
@@ -27,3 +29,16 @@ const incvar = {
 	thread.xadd(&done, 1)
 }
 
+const testintptr = {
+	var i = 123
+	var j = 456
+	var p = &i
+
+	std.assert(std.get(thread.xgetptr(&p))# == 123, "xgetptr is broken\n")
+	thread.xsetptr(&p, `std.Some &j)
+	std.assert(p# == 456, "xsetptr is broken\n")
+	std.assert(std.get(thread.xcasptr(&p, `std.Some &j, `std.Some &i)) == &j, "xcasptr is broken\n")
+	std.assert(p# == 123, "xcasptr is broken\n")
+	std.assert(std.get(thread.xchgptr(&p, `std.None)) == &i, "xchgptr is broken\n")
+	std.assert((p : std.intptr) == 0, "xchgptr is broken\n")
+}


### PR DESCRIPTION
Felt like it would be nice to be able to perform atomic operations on pointers without having to constantly cast to and from intptr. Not 100% sure about using options for literally everything but it seems better than having to define Zptr in order to null a pointer.