### PR TITLE
Fixes for bio.readto

### DIFF
--- a/lib/bio/bio.myr
+++ b/lib/bio/bio.myr
@@ -427,7 +427,7 @@ const readdelim = {f, delim, mode
 		for i = f.rstart; i <= f.rend - delim.len; i++
 			for j = 0; j < delim.len; j++
 				if f.rbuf[i + j] != delim[j]
-					goto notfound
+					goto nextiter
 				;;
 			;;
 			/* If we found it, return that information */
@@ -438,12 +438,11 @@ const readdelim = {f, delim, mode
 			;;
 			f.rstart += delim.len
 			-> `std.Ok ret
-:notfound
-			f.rstart = i
+:nextiter
 		;;
 		match mode
 		| `Drop:	f.rstart = i
-		| `Read:	readinto(f, &ret, f.rend - f.rstart)
+		| `Read:	readinto(f, &ret, i - f.rstart)
 		| `Keep:
 		;;
 	;;

--- a/lib/bio/bio.myr
+++ b/lib/bio/bio.myr
@@ -395,10 +395,8 @@ const unwrapc = {cc, v
 
 const readdelim = {f, delim, mode
 	var ret, i, j
-	var pr
 
 	ret = [][:]
-	pr = false
 	if delim.len == 0
 		-> `std.Ok ret
 	;;
@@ -421,7 +419,9 @@ const readdelim = {f, delim, mode
 			| 0:	-> `std.Err `Eof
 			| _:	-> `std.Ok ret
 			;;
-		| `std.Err e:	-> `std.Err e
+		| `std.Err e:
+			std.slfree(ret)
+			-> `std.Err e
 		| `std.Ok _:	/* nothing: scan the buffer */
 		;;
 		for i = f.rstart; i <= f.rend - delim.len; i++


### PR DESCRIPTION
A few things: 

1. bio.readto currently only returns the last character found, as f.rstart is being incremented on each iteration. As far as I can tell this is unnecessary, as it isn't read again in the loop, and so only needs to be set for the `Drop` case when the delimiter is found or the loop ends, which is already being done. Removing that makes readto work, and doesn't appear to change the behaviour of bio.skipto. 

2. Only readinto() the part of the buffer that was checked. This makes readto work when the delimiter crosses the Buffsz boundary, same as skipto does. 

3. Free ret in case of non-eof error, as it may have had data allocated on a previous iteration.