### PR TITLE
Allow optional eol after the commas of function parameters

### DIFF
--- a/parse/gram.y
+++ b/parse/gram.y
@@ -936,7 +936,7 @@ params	: fnparam {
 		$$.nn = 0;
 		lappend(&$$.nl, &$$.nn, $1);
 	}
-	| params Tcomma fnparam {lappend(&$$.nl, &$$.nn, $3);}
+	| params listsep fnparam {lappend(&$$.nl, &$$.nn, $3);}
 	| /* empty */ {$$.nl = NULL; $$.nn = 0;}
 	;
 


### PR DESCRIPTION
So we can break long parameters into lines without '\\'.

For example,
```
const foo = {a : byte[:], \
	     b : int
}
```
can become
```
const foo = {a : byte[:],
	     b : int
}
```