### PR TITLE
Support or-pattern

### DIFF
--- a/mi/match.c
+++ b/mi/match.c
@@ -941,7 +941,7 @@ gendtree(Node *m, Node *val, Node **lbl, size_t nlbl)
 		genfrontier(i, val, pat[i]->match.pat, lbl[i], &frontier, &nfrontier);
 	}
 
-	// to determine if two different sets of captures come from a or-pattern, which is NOT allowed.
+	/* to determine if two different sets of captures come from a or-pattern, which is NOT allowed. */
 	last = NULL;
 	for (i = 0; i < nfrontier; i++) {
 		cur = frontier[i];

--- a/mi/match.c
+++ b/mi/match.c
@@ -459,8 +459,7 @@ addrec(Frontier *fs, Node *pat, Node *val, Path *path)
 	switch (exprop(pat)) {
 	case Olor:
 		next = frontierdup(fs);
-		if (fs->next)
-			next->next = fs->next;
+		next->next = fs->next;
 		fs->next = next;
 		addrec(fs, pat->expr.args[1], val, path);
 		addrec(next, pat->expr.args[0], val, path);

--- a/mi/match.c
+++ b/mi/match.c
@@ -913,7 +913,7 @@ capeq(Node *a, Node *b)
 	va = a->expr.args[1];
 	vb = b->expr.args[1];
 
-	return decltype(decls[pa->expr.did]) == decltype(decls[pb->expr.did]) && loadeq(va, vb);
+	return pa->expr.did == pb->expr.did && loadeq(va, vb);
 }
 
 Dtree *

--- a/mi/match.c
+++ b/mi/match.c
@@ -459,6 +459,8 @@ addrec(Frontier *fs, Node *pat, Node *val, Path *path)
 	switch (exprop(pat)) {
 	case Olor:
 		next = frontierdup(fs);
+		if (fs->next)
+			next->next = fs->next;
 		fs->next = next;
 		addrec(fs, pat->expr.args[1], val, path);
 		addrec(next, pat->expr.args[0], val, path);

--- a/mi/match.c
+++ b/mi/match.c
@@ -906,7 +906,14 @@ clearemit(Dtree *dt)
 static int
 capeq(Node *a, Node *b)
 {
-	return 1;
+	Node *pa, *pb, *va, *vb;
+
+	pa = a->expr.args[0];
+	pb = b->expr.args[0];
+	va = a->expr.args[1];
+	vb = b->expr.args[1];
+
+	return decltype(decls[pa->expr.did]) == decltype(decls[pb->expr.did]) && loadeq(va, vb);
 }
 
 Dtree *

--- a/mi/match.c
+++ b/mi/match.c
@@ -458,9 +458,9 @@ addrec(Frontier *fs, Node *pat, Node *val, Path *path)
 	pat = fold(pat, 1);
 	switch (exprop(pat)) {
 	case Olor:
-		addrec(fs, pat->expr.args[1], val, path);
 		next = frontierdup(fs);
 		fs->next = next;
+		addrec(fs, pat->expr.args[1], val, path);
 		addrec(next, pat->expr.args[0], val, path);
 		break;
 	case Ogap:
@@ -938,10 +938,10 @@ gendtree(Node *m, Node *val, Node **lbl, size_t nlbl)
 		cur = frontier[i];
 		if (last && last->i == cur->i) {
 			if (last->ncap != cur->ncap)
-				fatal(pat[cur->i], "captured variables are not equally bound in all or-pattern of the same group");
+				fatal(pat[cur->i], "number of wildcard variables in the or-patterns are not equal (%d != %d)", last->ncap, cur->ncap);
 			for (j = 0; j < cur->ncap; j++) {
 				if (!capeq(last->cap[j], cur->cap[j]))
-					fatal(pat[cur->i], "captured variables are not equally bound in all or-pattern of the same group");
+					fatal(pat[cur->i], "wildcard variables have different types in the or-patterns");
 			}
 		} else {
 			addcapture(pat[cur->i]->match.block, cur->cap, cur->ncap);

--- a/parse/infer.c
+++ b/parse/infer.c
@@ -1716,7 +1716,6 @@ inferexpr(Node **np, Type *ret, int *sawret)
 	case Obsreq:	/* @a >>= @a -> @a */
 		infersub(n, ret, sawret, &isconst);
 		t = type(args[0]);
-
 		constrain(n, t, traittab[Tcnum]);
 		constrain(n, t, traittab[Tcint]);
 		isconst = args[0]->expr.isconst;

--- a/parse/infer.c
+++ b/parse/infer.c
@@ -1535,7 +1535,6 @@ inferpat(Node **np, Node *val, Node ***bind, size_t *nbind)
 	args = n->expr.args;
 	for (i = 0; i < n->expr.nargs; i++)
 		if (args[i]->type == Nexpr) {
-			args[i]->expr.ispat = 1;
 			inferpat(&args[i], val, bind, nbind);
 		}
 	switch (exprop(n)) {

--- a/parse/parse.h
+++ b/parse/parse.h
@@ -237,6 +237,7 @@ struct Node {
 			Type *type;
 			Type *param;	/* for specialized traits, the primary param */
 			int isconst;
+			int ispat;
 			size_t did;	/* for Ovar, we want a mapping to the decl id */
 			size_t nargs;
 			Node *idx;	/* used when this is in an indexed initializer */

--- a/test/matchor.myr
+++ b/test/matchor.myr
@@ -41,5 +41,25 @@ const main = {
 	| _: std.exit(1)
 	;;
 
+	type bar = union
+		`A int
+		`B int
+		`C int
+		`D (byte[:], int)
+		`E (byte[:], int)
+		`F (int, std.option(int))
+		`G (int, std.option(int))
+	;;
+
+	match `A 123
+	| `A x || `B x: std.put("good #4 {}\n", x)
+	| _: std.exit(1)
+	;;
+
+	match `G (223, `std.Some 556)
+	| `F (x, `std.Some y) || `G (x, `std.Some y): std.put("good #5 x={} y={}\n", x, y)
+	| _: std.exit(1)
+	;;
+
 	std.put("all good\n")
 }

--- a/test/matchor.myr
+++ b/test/matchor.myr
@@ -1,0 +1,45 @@
+use std
+
+
+const main = {
+	type foo = union
+		`Black
+		`Blue
+		`Green
+		`Red
+		`Yellow
+		`White
+	;;
+
+	match `Green
+	| `Black || `White: std.exit(1)
+	| `Blue || `Green || `Red: std.put("color\n")
+	| _: std.exit(1)
+	;;
+
+	match `std.Some 100
+	| `std.Some (100 || 200 || 300): std.put("hundreds\n")
+	| `std.Some _: std.exit(1)
+	| _: std.exit(1)
+	;;
+
+	match `std.Some (`std.Some 333, 123, 789)
+	| `std.Some (`std.Some (101||451||789||333), _, _): std.put("good #1\n")
+	| `std.Some (`std.Some (100||200), 222, 333): std.exit(1)
+	| `std.Some _: std.exit(1)
+	| `std.None: std.exit(1)
+	;;
+
+	match 4
+	| 1||2||4: std.put("good $2\n")
+	| _: std.exit(1)
+	;;
+
+	const a = 4
+	match 4
+	| 1||2||a: std.put("good $3\n")
+	| _: std.exit(1)
+	;;
+
+	std.put("all good\n")
+}

--- a/test/tests
+++ b/test/tests
@@ -127,6 +127,7 @@ B matchnest	P	'abcdef'
 F matchmixed
 F matchoverlap
 B matchctup	P	'l = [0, 1, 2, 3] n = 5'
+B matchor	E	0
 B bigliteral	P	34359738368
 B fltabs	P	'42.0'
 B arraylit-ni	E	2


### PR DESCRIPTION
Examples:
```
type foo = union
        `Black
        `Blue
        `Green
        `Red
        `Yellow
        `White
;;
match `Green
| `Black || `White: std.put("monochrome\n")
| `Blue || `Green || `Red: std.put("color\n")
| _: std.put("others")  
;;
// output: color
``` 
```
match `std.Some 100
| `std.Some (100 ||200 ||300): std.put("hundreds\n")
| `std.Some _: std.put("other values\n")
| _: std.put("no value\n")
;;
// output: hundreds
```
```
match `std.Some (`std.Some 333, 123, 789)
| `std.Some (`std.Some (101||451||789||333), _, _): std.put("good\n")
| `std.Some (`std.Some (100||200), 222, 333): std.put("bad\n")
| `std.Some _: std.put("Some _\n")
| `std.None: std.put("None\n")
;;
// output: good
```

